### PR TITLE
Add the `RKDropdownAlert` to the current view controller.

### DIFF
--- a/SlingshotDropdownAlert/RKDropdownAlert.m
+++ b/SlingshotDropdownAlert/RKDropdownAlert.m
@@ -214,7 +214,7 @@ NSString *DEFAULT_TITLE;
         
         for (UIWindow *window in frontToBackWindows)
             if (window.windowLevel == UIWindowLevelNormal) {
-                [window.rootViewController.view addSubview:self];
+                [[[window subviews] lastObject] addSubview:self];
                 break;
             }
     }


### PR DESCRIPTION
If a view controller was presented as modal, it would obscure the `RKDropdownAlert` from view. Using this method, the alert view is added to the currently visible view controller. Oftentimes, that's still the root view controller (this was tested), but there are some cases where it's a different view controller.

We're hoping to use `RKDropdownAlert` in the iOS App for the Storybird (storybird.com), but it's a non-starter for us without this patch.
