### PR TITLE
Avoid Overlapping RKDropdownAlerts

### DIFF
--- a/SlingshotDropdownAlert/RKDropdownAlert.h
+++ b/SlingshotDropdownAlert/RKDropdownAlert.h
@@ -36,6 +36,7 @@ extern NSString *const RKDropdownAlertDismissAllNotification;
 
 @protocol RKDropdownAlertDelegate <NSObject>
 -(BOOL)dropdownAlertWasTapped:(RKDropdownAlert*)alert;
+-(BOOL)dropdownAlertWasDismissed;
 @end
 
 @interface RKDropdownAlert : UIButton
@@ -67,6 +68,7 @@ extern NSString *const RKDropdownAlertDismissAllNotification;
 
 @property UIColor *defaultViewColor;
 @property UIColor *defaultTextColor;
+@property BOOL isShowing;
 @property id<RKDropdownAlertDelegate> delegate;
 
 -(void)title:(NSString*)title message:(NSString*)message backgroundColor:(UIColor*)backgroundColor textColor:(UIColor*)textColor time:(NSInteger)seconds;

--- a/SlingshotDropdownAlert/RKDropdownAlert.m
+++ b/SlingshotDropdownAlert/RKDropdownAlert.m
@@ -78,6 +78,7 @@ NSString *DEFAULT_TITLE;
                                                  selector:@selector(dismissAlertView)
                                                      name:RKDropdownAlertDismissAllNotification
                                                    object:nil];
+        self.isShowing = NO;
 
     }
     return self;
@@ -122,6 +123,10 @@ NSString *DEFAULT_TITLE;
 {
     if (alertView){
         [alertView removeFromSuperview];
+        self.isShowing = NO;
+        if (self.delegate){
+            [self.delegate dropdownAlertWasDismissed];
+        }
     }
 }
 
@@ -291,6 +296,8 @@ NSString *DEFAULT_TITLE;
                 break;
             }
     }
+    
+    self.isShowing = YES;
     
     [UIView animateWithDuration:ANIMATION_TIME animations:^{
         CGRect frame = self.frame;


### PR DESCRIPTION
add isShowing property and dropdownAlertWasDismissed delegate callback to help avoid overlapping RKDropdownAlerts.

I've had a need for this when using RKDA to display connection errors on calls and multiple calls are made in quick succession: this leads to a large number of RKDAs to overlap.
![overlappingrkda](https://cloud.githubusercontent.com/assets/3359083/6101579/69f9a134-aff4-11e4-9415-88183ef4009b.png)

